### PR TITLE
Implement MessagePack message serializer based on annotations

### DIFF
--- a/skyblock-bukkit/src/main/java/io/github/cdfn/skyblock/messages/PlayerDataMessages.java
+++ b/skyblock-bukkit/src/main/java/io/github/cdfn/skyblock/messages/PlayerDataMessages.java
@@ -4,7 +4,6 @@ import io.github.cdfn.skyblock.commons.messages.api.MessagePackSerializable;
 import io.github.cdfn.skyblock.util.playerdata.PlayerData;
 import java.io.IOException;
 import java.util.UUID;
-import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
 
 public class PlayerDataMessages {
@@ -17,10 +16,10 @@ public class PlayerDataMessages {
     }
 
     @Override
-    public MessageBufferPacker serialize() throws IOException {
+    public byte[] serialize() throws IOException {
       try(var packer = MessagePack.newDefaultBufferPacker()) {
         packer.packString(this.uuid.toString());
-        return packer;
+        return packer.toByteArray();
       }
     }
 
@@ -46,7 +45,7 @@ public class PlayerDataMessages {
     }
 
     @Override
-    public MessageBufferPacker serialize() throws IOException {
+    public byte[] serialize() throws IOException {
       try(var packer = MessagePack.newDefaultBufferPacker()) {
         packer.packString(this.uuid.toString());
 
@@ -62,7 +61,7 @@ public class PlayerDataMessages {
         packer.packArrayHeader(statistics.length);
         packer.writePayload(statistics);
 
-        return packer;
+        return packer.toByteArray();
       }
 
     }

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/ConfigMessages.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/ConfigMessages.java
@@ -2,7 +2,6 @@ package io.github.cdfn.skyblock.commons.messages;
 
 import io.github.cdfn.skyblock.commons.messages.api.MessagePackSerializable;
 import java.io.IOException;
-import org.msgpack.core.MessageBufferPacker;
 import org.msgpack.core.MessagePack;
 
 public class ConfigMessages {
@@ -16,10 +15,10 @@ public class ConfigMessages {
     }
 
     @Override
-    public MessageBufferPacker serialize() throws IOException {
+    public byte[] serialize() throws IOException {
       try(var packer = MessagePack.newDefaultBufferPacker()) {
         packer.packInt(this.id);
-        return packer;
+        return packer.toByteArray();
       }
     }
 
@@ -46,11 +45,11 @@ public class ConfigMessages {
     }
 
     @Override
-    public MessageBufferPacker serialize() throws IOException {
+    public byte[] serialize() throws IOException {
       try(var packer = MessagePack.newDefaultBufferPacker()) {
         packer.packInt(this.id);
         packer.packString(this.data);
-        return packer;
+        return packer.toByteArray();
       }
     }
 

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/ConfigMessages.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/ConfigMessages.java
@@ -1,32 +1,17 @@
 package io.github.cdfn.skyblock.commons.messages;
 
-import io.github.cdfn.skyblock.commons.messages.api.MessagePackSerializable;
-import java.io.IOException;
-import org.msgpack.core.MessagePack;
+import io.github.cdfn.skyblock.commons.messages.api.AnnotationMessageSerializer;
+import io.github.cdfn.skyblock.commons.messages.api.MessagePackField;
 
 public class ConfigMessages {
 
-  public static class ConfigRequest implements MessagePackSerializable {
+  public static class ConfigRequest implements AnnotationMessageSerializer {
 
-    private int id;
+    @MessagePackField
+    private Integer id;
 
     public ConfigRequest(int id) {
       this.id = id;
-    }
-
-    @Override
-    public byte[] serialize() throws IOException {
-      try(var packer = MessagePack.newDefaultBufferPacker()) {
-        packer.packInt(this.id);
-        return packer.toByteArray();
-      }
-    }
-
-    @Override
-    public void deserialize(byte[] bytes) throws IOException {
-      try(var unpacker = MessagePack.newDefaultUnpacker(bytes)) {
-        this.id = unpacker.unpackInt();
-      }
     }
 
     public int getId() {
@@ -34,31 +19,16 @@ public class ConfigMessages {
     }
   }
 
-  public static class ConfigResponse implements MessagePackSerializable {
+  public static class ConfigResponse implements AnnotationMessageSerializer {
 
-    private int id;
+    @MessagePackField
+    private Integer id;
+    @MessagePackField
     private String data;
 
     public ConfigResponse(int id, String data) {
       this.id = id;
       this.data = data;
-    }
-
-    @Override
-    public byte[] serialize() throws IOException {
-      try(var packer = MessagePack.newDefaultBufferPacker()) {
-        packer.packInt(this.id);
-        packer.packString(this.data);
-        return packer.toByteArray();
-      }
-    }
-
-    @Override
-    public void deserialize(byte[] bytes) throws IOException {
-      try(var unpacker = MessagePack.newDefaultUnpacker(bytes)) {
-        this.id = unpacker.unpackInt();
-        this.data = unpacker.unpackString();
-      }
     }
 
     public int getId() {

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
@@ -1,0 +1,126 @@
+package io.github.cdfn.skyblock.commons.messages.api;
+
+import io.github.cdfn.skyblock.commons.messages.util.sneaky.SneakyBiConsumer;
+import io.github.cdfn.skyblock.commons.messages.util.sneaky.SneakyFunction;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import org.msgpack.core.MessageBufferPacker;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessagePacker;
+import org.msgpack.core.MessageUnpacker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public interface AnnotationMessageSerializer extends MessagePackSerializable {
+
+  Logger LOGGER = LoggerFactory.getLogger(AnnotationMessageSerializer.class);
+  Map<Class<?>, Map.Entry<BiConsumer, Function>> serializationStrategies = createStrategies();
+
+  static Map<Class<?>, Map.Entry<BiConsumer, Function>> createStrategies() {
+    var map = new HashMap<Class<?>, Map.Entry<BiConsumer, Function>>();
+    map.put(BigInteger.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, BigInteger, IOException>) MessagePacker::packBigInteger),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, BigInteger, IOException>) MessageUnpacker::unpackBigInteger)
+    ));
+    map.put(Boolean.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Boolean, IOException>) MessagePacker::packBoolean),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Boolean, IOException>) MessageUnpacker::unpackBoolean)
+    ));
+    map.put(Byte.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Byte, IOException>) MessagePacker::packByte),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Byte, IOException>) MessageUnpacker::unpackByte)
+    ));
+    map.put(Double.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Double, IOException>) MessagePacker::packDouble),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Double, IOException>) MessageUnpacker::unpackDouble)
+    ));
+    map.put(Float.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Float, IOException>) MessagePacker::packFloat),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Float, IOException>) MessageUnpacker::unpackFloat)
+    ));
+    map.put(Integer.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Integer, IOException>) MessagePacker::packInt),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Integer, IOException>) MessageUnpacker::unpackInt)
+    ));
+    map.put(Long.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Long, IOException>) MessagePacker::packLong),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Long, IOException>) MessageUnpacker::unpackLong)
+    ));
+    map.put(Short.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, Short, IOException>) MessagePacker::packShort),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, Short, IOException>) MessageUnpacker::unpackShort)
+    ));
+    map.put(String.class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, String, IOException>) MessagePacker::packString),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, String, IOException>) MessageUnpacker::unpackString)
+        ));
+    map.put(byte[].class, Map.entry(
+        SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, byte[], IOException>) (packer, bytes) -> {
+          packer.packArrayHeader(bytes.length);
+          packer.writePayload(bytes);
+        }),
+        SneakyFunction.of((SneakyFunction<MessageUnpacker, byte[], IOException>) (unpacker) -> unpacker.readPayload(unpacker.unpackArrayHeader()))
+    ));
+    return map;
+  }
+
+  @Override
+  default byte[] serialize() {
+    try (var packer = MessagePack.newDefaultBufferPacker()) {
+      for (Field field : this.getClass().getDeclaredFields()) {
+        field.setAccessible(true);
+        if (field.getAnnotation(MessagePackField.class) == null) {
+          continue;
+        }
+
+        Object o = field.get(this);
+        Class<?> type = field.getType();
+        if (o == null) {
+          packer.packNil();
+          continue;
+        }
+
+        var strategy = serializationStrategies.get(type).getKey();
+        if(strategy == null) {
+          throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
+        }
+
+        strategy.accept(packer, o);
+      }
+      return packer.toByteArray();
+    } catch (IllegalAccessException | IOException e) {
+      LOGGER.error("Failed to pack message", e);
+    }
+    return null;
+  }
+
+  @Override
+  default void deserialize(byte[] bytes) {
+    try(var unpacker = MessagePack.newDefaultUnpacker(bytes)){
+      for (Field field : this.getClass().getDeclaredFields()) {
+        field.setAccessible(true);
+        if (field.getAnnotation(MessagePackField.class) == null) {
+          continue;
+        }
+
+        Class<?> type = field.getType();
+
+        var strategy = serializationStrategies.get(type).getValue();
+        if(strategy == null) {
+          throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
+        }
+
+        var result = strategy.apply(unpacker);
+        field.set(this, result);
+      }
+    } catch (IllegalAccessException | IOException e ) {
+      LOGGER.error("Failed to unpack message", e);
+    }
+  }
+}

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
@@ -60,7 +60,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
     map.put(String.class, Map.entry(
         SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, String, IOException>) MessagePacker::packString),
         SneakyFunction.of((SneakyFunction<MessageUnpacker, String, IOException>) MessageUnpacker::unpackString)
-        ));
+    ));
     map.put(byte[].class, Map.entry(
         SneakyBiConsumer.of((SneakyBiConsumer<MessageBufferPacker, byte[], IOException>) (packer, bytes) -> {
           packer.packArrayHeader(bytes.length);
@@ -89,7 +89,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
         }
 
         var strategy = serializationStrategies.get(type).getKey();
-        if(strategy == null) {
+        if (strategy == null) {
           throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
         }
 
@@ -105,7 +105,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
 
   @Override
   default void deserialize(byte[] bytes) {
-    try(var unpacker = MessagePack.newDefaultUnpacker(bytes)){
+    try (var unpacker = MessagePack.newDefaultUnpacker(bytes)) {
       for (Field field : this.getClass().getDeclaredFields()) {
         field.setAccessible(true);
         // Skip fields without MessagePackField annotation
@@ -116,7 +116,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
         Class<?> type = field.getType();
 
         var strategy = serializationStrategies.get(type).getValue();
-        if(strategy == null) {
+        if (strategy == null) {
           throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
         }
 
@@ -124,7 +124,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
         var result = strategy.apply(unpacker);
         field.set(this, result);
       }
-    } catch (IllegalAccessException | IOException e ) {
+    } catch (IllegalAccessException | IOException e) {
       LOGGER.error("Failed to unpack message", e);
     }
   }

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 public interface AnnotationMessageSerializer extends MessagePackSerializable {
 
   Logger LOGGER = LoggerFactory.getLogger(AnnotationMessageSerializer.class);
+  // Map<Class, Pair<SerializationStrategy, DeserializationStrategy>>
   Map<Class<?>, Map.Entry<BiConsumer, Function>> serializationStrategies = createStrategies();
 
   static Map<Class<?>, Map.Entry<BiConsumer, Function>> createStrategies() {
@@ -75,6 +76,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
     try (var packer = MessagePack.newDefaultBufferPacker()) {
       for (Field field : this.getClass().getDeclaredFields()) {
         field.setAccessible(true);
+        // Skip fields without MessagePackField annotation
         if (field.getAnnotation(MessagePackField.class) == null) {
           continue;
         }
@@ -91,6 +93,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
           throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
         }
 
+        // Pack object using packer
         strategy.accept(packer, o);
       }
       return packer.toByteArray();
@@ -105,6 +108,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
     try(var unpacker = MessagePack.newDefaultUnpacker(bytes)){
       for (Field field : this.getClass().getDeclaredFields()) {
         field.setAccessible(true);
+        // Skip fields without MessagePackField annotation
         if (field.getAnnotation(MessagePackField.class) == null) {
           continue;
         }
@@ -116,6 +120,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
           throw new UnsupportedOperationException(String.format("unknown type %s in %s", field.getType().getName(), this.getClass().getName()));
         }
 
+        // Unpack value using unpacker and set field's value to unpacked one
         var result = strategy.apply(unpacker);
         field.set(this, result);
       }

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/AnnotationMessageSerializer.java
@@ -81,9 +81,9 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
           continue;
         }
 
-        Object o = field.get(this);
+        Object fieldValue = field.get(this);
         Class<?> type = field.getType();
-        if (o == null) {
+        if (fieldValue == null) {
           packer.packNil();
           continue;
         }
@@ -94,7 +94,7 @@ public interface AnnotationMessageSerializer extends MessagePackSerializable {
         }
 
         // Pack object using packer
-        strategy.accept(packer, o);
+        strategy.accept(packer, fieldValue);
       }
       return packer.toByteArray();
     } catch (IllegalAccessException | IOException e) {

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePackField.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePackField.java
@@ -1,0 +1,12 @@
+package io.github.cdfn.skyblock.commons.messages.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface MessagePackField {
+
+}

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePackSerializable.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePackSerializable.java
@@ -1,11 +1,10 @@
 package io.github.cdfn.skyblock.commons.messages.api;
 
 import java.io.IOException;
-import org.msgpack.core.MessageBufferPacker;
 
 public interface MessagePackSerializable {
 
-  MessageBufferPacker serialize() throws IOException;
+  byte[] serialize() throws IOException;
 
   void deserialize(byte[] bytes) throws IOException;
 }

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePublisher.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/api/MessagePublisher.java
@@ -22,7 +22,7 @@ public class MessagePublisher {
     try {
       commands.publish(
           RedisConfig.PREFIX + className,
-          message.serialize().toByteArray()
+          message.serialize()
       );
     } catch (IOException e) {
       LOGGER.error("error while publishing message {}", className, e);

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyBiConsumer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyBiConsumer.java
@@ -1,0 +1,17 @@
+package io.github.cdfn.skyblock.commons.messages.util.sneaky;
+
+import java.util.function.BiConsumer;
+
+public interface SneakyBiConsumer<T, U, E extends Exception> {
+    static <T, U> BiConsumer<T, U> of(SneakyBiConsumer<? super T, ? super U, ? extends Exception> cons) {
+      return (e, f) -> {
+        try {
+          cons.accept(e, f);
+        } catch (Exception ex) {
+          SneakyUtil.sneakyThrow(ex);
+        }
+      };
+    }
+
+    void accept(T t, U u) throws E;
+}

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyConsumer.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyConsumer.java
@@ -1,0 +1,17 @@
+package io.github.cdfn.skyblock.commons.messages.util.sneaky;
+
+import java.util.function.Consumer;
+
+public interface SneakyConsumer<T, E extends Exception> {
+  static <T> Consumer<T> of(SneakyConsumer<? super T, ? extends Exception> cons) {
+    return e -> {
+      try {
+        cons.accept(e);
+      } catch (Exception ex) {
+        SneakyUtil.sneakyThrow(ex);
+      }
+    };
+  }
+
+  void accept(T t) throws E;
+}

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyFunction.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyFunction.java
@@ -1,0 +1,18 @@
+package io.github.cdfn.skyblock.commons.messages.util.sneaky;
+
+import java.util.function.Function;
+
+public interface SneakyFunction<T, U, E extends Exception> {
+  static <T, U> Function<T, U> of(SneakyFunction<? super T, U, ? extends Exception> cons) {
+    return e -> {
+      try {
+        return cons.apply(e);
+      } catch (Exception ex) {
+        SneakyUtil.sneakyThrow(ex);
+      }
+      return null;
+    };
+  }
+
+  U apply(T t) throws E;
+}

--- a/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyUtil.java
+++ b/skyblock-common/src/main/java/io/github/cdfn/skyblock/commons/messages/util/sneaky/SneakyUtil.java
@@ -1,0 +1,8 @@
+package io.github.cdfn.skyblock.commons.messages.util.sneaky;
+
+public abstract class SneakyUtil {
+  @SuppressWarnings("unchecked")
+  static <E extends Exception> void sneakyThrow(Exception e) throws E {
+    throw (E) e;
+  }
+}


### PR DESCRIPTION
Example message:
```java
public class TestMessage implements AnnotationMessageSerializer {
  @MessagePackField
  private byte[] testBytesField;
  @MessagePackField
  private String testStringField;

  public TestMessage(byte[] bytes, String s){
    this.testBytesField = bytes;
    this.testStringFIeld = s;
  }
}
```

Supported types:
- BigInteger
- Boolean
- Byte
- Double
- Float
- Integer
- Long
- Short
- String
- byte[]